### PR TITLE
fix: remove duplicate Tailwind CDN import from HTML pages

### DIFF
--- a/aboutus.html
+++ b/aboutus.html
@@ -12,7 +12,6 @@
         rel="stylesheet">
 
     <!-- Tailwind CSS -->
-    <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
 
     <!-- Font Awesome -->

--- a/article.html
+++ b/article.html
@@ -12,7 +12,6 @@
         rel="stylesheet">
 
     <!-- Tailwind CSS -->
-    <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
 
     <!-- Font Awesome -->

--- a/blog.html
+++ b/blog.html
@@ -12,7 +12,6 @@
         rel="stylesheet">
 
     <!-- Tailwind CSS -->
-    <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
 
     <!-- Font Awesome -->

--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
         rel="stylesheet">
 
     <!-- Tailwind CSS -->
-    <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
 
     <!-- Font Awesome -->


### PR DESCRIPTION
## What changed
- Removed duplicate Tailwind CDN script
- Ensured Tailwind is loaded once with the typography plugin