### PR TITLE
Add 8 new datasets to timeline and fix EN date bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -1161,6 +1161,286 @@
                         <!-- Vertical Line -->
                         <div class="timeline-line"></div>
 
+                        <!-- Item 21: eellak-articles -->
+                        <div class="roadmap-item relative mb-12 w-1/2 pr-6 sm:pr-12 text-right" data-index="21" id="roadmap-item-21">
+                            <div class="timeline-node node-left" id="node-21"></div>
+
+                            <div class="glass-box relative p-[5px] hover:border-purple-500/50 transition-colors group cursor-pointer"
+                                data-theme="purple" onclick="highlightChartPoint(21)">
+
+                                <a href="https://huggingface.co/datasets/glossAPI/eellak-articles"
+                                target="_blank" class="absolute inset-0 z-20">
+                                </a>
+
+                                <div class="bg-[#0f0b16]/80 rounded-[0.9rem] p-6 h-full w-full relative overflow-hidden">
+                                    <div class="mb-3">
+                                        <span class="inline-flex items-center px-3 py-1 rounded-full text-[10px] sm:text-xs font-bold bg-purple-500/10 backdrop-blur-md border border-purple-500/20 text-purple-300 uppercase tracking-wider shadow-lg">
+                                            <span class="w-1.5 h-1.5 bg-purple-400 rounded-full mr-2 animate-pulse"></span>
+                                            <span id="date-21">ΑΠΡ 2026</span>
+                                        </span>
+                                    </div>
+
+                                    <h3 class="text-lg sm:text-xl font-bold text-white mb-2 group-hover:text-purple-300 transition-colors break-words">
+                                        eellak-articles
+                                    </h3>
+
+                                    <div class="flex justify-end gap-2 sm:gap-4 mb-3 flex-wrap">
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-database mr-1"></i> 25.10MB
+                                        </div>
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-layer-group mr-1"></i> 8.5M Tokens
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Item 20: opengov-deliberations-v2 -->
+                        <div class="roadmap-item relative mb-12 w-1/2 ml-auto pl-6 sm:pl-12 text-left" data-index="20" id="roadmap-item-20">
+                            <div class="timeline-node node-right" id="node-20"></div>
+
+                            <div class="glass-box relative p-[5px] hover:border-purple-500/50 transition-colors group cursor-pointer"
+                                data-theme="purple" onclick="highlightChartPoint(20)">
+
+                                <a href="https://huggingface.co/datasets/glossAPI/opengov-deliberations-v2"
+                                target="_blank" class="absolute inset-0 z-20">
+                                </a>
+
+                                <div class="bg-[#0f0b16]/80 rounded-[0.9rem] p-6 h-full w-full relative overflow-hidden">
+                                    <div class="mb-3">
+                                        <span class="inline-flex items-center px-3 py-1 rounded-full text-[10px] sm:text-xs font-bold bg-purple-500/10 backdrop-blur-md border border-purple-500/20 text-purple-300 uppercase tracking-wider shadow-lg">
+                                            <span class="w-1.5 h-1.5 bg-purple-400 rounded-full mr-2 animate-pulse"></span>
+                                            <span id="date-20">ΑΠΡ 2026</span>
+                                        </span>
+                                    </div>
+
+                                    <h3 class="text-lg sm:text-xl font-bold text-white mb-2 group-hover:text-purple-300 transition-colors break-words">
+                                        opengov-deliberations-v2
+                                    </h3>
+
+                                    <div class="flex gap-2 sm:gap-4 mb-3 flex-wrap">
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-database mr-1"></i> 357.71MB
+                                        </div>
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-layer-group mr-1"></i> 111.4M Tokens
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Item 19: enautilia -->
+                        <div class="roadmap-item relative mb-12 w-1/2 pr-6 sm:pr-12 text-right" data-index="19" id="roadmap-item-19">
+                            <div class="timeline-node node-left" id="node-19"></div>
+
+                            <div class="glass-box relative p-[5px] hover:border-purple-500/50 transition-colors group cursor-pointer"
+                                data-theme="purple" onclick="highlightChartPoint(19)">
+
+                                <a href="https://huggingface.co/datasets/glossAPI/enautilia"
+                                target="_blank" class="absolute inset-0 z-20">
+                                </a>
+
+                                <div class="bg-[#0f0b16]/80 rounded-[0.9rem] p-6 h-full w-full relative overflow-hidden">
+                                    <div class="mb-3">
+                                        <span class="inline-flex items-center px-3 py-1 rounded-full text-[10px] sm:text-xs font-bold bg-purple-500/10 backdrop-blur-md border border-purple-500/20 text-purple-300 uppercase tracking-wider shadow-lg">
+                                            <span class="w-1.5 h-1.5 bg-purple-400 rounded-full mr-2 animate-pulse"></span>
+                                            <span id="date-19">ΑΠΡ 2026</span>
+                                        </span>
+                                    </div>
+
+                                    <h3 class="text-lg sm:text-xl font-bold text-white mb-2 group-hover:text-purple-300 transition-colors break-words">
+                                        enautilia
+                                    </h3>
+
+                                    <div class="flex justify-end gap-2 sm:gap-4 mb-3 flex-wrap">
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-database mr-1"></i> 4.61MB
+                                        </div>
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-layer-group mr-1"></i> 2.7M Tokens
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Item 18: artoszois -->
+                        <div class="roadmap-item relative mb-12 w-1/2 ml-auto pl-6 sm:pl-12 text-left" data-index="18" id="roadmap-item-18">
+                            <div class="timeline-node node-right" id="node-18"></div>
+
+                            <div class="glass-box relative p-[5px] hover:border-purple-500/50 transition-colors group cursor-pointer"
+                                data-theme="purple" onclick="highlightChartPoint(18)">
+
+                                <a href="https://huggingface.co/datasets/glossAPI/artoszois"
+                                target="_blank" class="absolute inset-0 z-20">
+                                </a>
+
+                                <div class="bg-[#0f0b16]/80 rounded-[0.9rem] p-6 h-full w-full relative overflow-hidden">
+                                    <div class="mb-3">
+                                        <span class="inline-flex items-center px-3 py-1 rounded-full text-[10px] sm:text-xs font-bold bg-purple-500/10 backdrop-blur-md border border-purple-500/20 text-purple-300 uppercase tracking-wider shadow-lg">
+                                            <span class="w-1.5 h-1.5 bg-purple-400 rounded-full mr-2 animate-pulse"></span>
+                                            <span id="date-18">ΑΠΡ 2026</span>
+                                        </span>
+                                    </div>
+
+                                    <h3 class="text-lg sm:text-xl font-bold text-white mb-2 group-hover:text-purple-300 transition-colors break-words">
+                                        artoszois
+                                    </h3>
+
+                                    <div class="flex gap-2 sm:gap-4 mb-3 flex-wrap">
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-database mr-1"></i> 12.20MB
+                                        </div>
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-layer-group mr-1"></i> 4.0M Tokens
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Item 17: AMNA-press -->
+                        <div class="roadmap-item relative mb-12 w-1/2 pr-6 sm:pr-12 text-right" data-index="17" id="roadmap-item-17">
+                            <div class="timeline-node node-left" id="node-17"></div>
+
+                            <div class="glass-box relative p-[5px] hover:border-purple-500/50 transition-colors group cursor-pointer"
+                                data-theme="purple" onclick="highlightChartPoint(17)">
+
+                                <a href="https://huggingface.co/datasets/glossAPI/AMNA-press"
+                                target="_blank" class="absolute inset-0 z-20">
+                                </a>
+
+                                <div class="bg-[#0f0b16]/80 rounded-[0.9rem] p-6 h-full w-full relative overflow-hidden">
+                                    <div class="mb-3">
+                                        <span class="inline-flex items-center px-3 py-1 rounded-full text-[10px] sm:text-xs font-bold bg-purple-500/10 backdrop-blur-md border border-purple-500/20 text-purple-300 uppercase tracking-wider shadow-lg">
+                                            <span class="w-1.5 h-1.5 bg-purple-400 rounded-full mr-2 animate-pulse"></span>
+                                            <span id="date-17">ΑΠΡ 2026</span>
+                                        </span>
+                                    </div>
+
+                                    <h3 class="text-lg sm:text-xl font-bold text-white mb-2 group-hover:text-purple-300 transition-colors break-words">
+                                        AMNA-press
+                                    </h3>
+
+                                    <div class="flex justify-end gap-2 sm:gap-4 mb-3 flex-wrap">
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-database mr-1"></i> 1.48GB
+                                        </div>
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-layer-group mr-1"></i> 158.2M Tokens
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Item 16: ERT Press -->
+                        <div class="roadmap-item relative mb-12 w-1/2 ml-auto pl-6 sm:pl-12 text-left" data-index="16" id="roadmap-item-16">
+                            <div class="timeline-node node-right" id="node-16"></div>
+
+                            <div class="glass-box relative p-[5px] hover:border-purple-500/50 transition-colors group cursor-pointer"
+                                data-theme="purple" onclick="highlightChartPoint(16)">
+
+                                <a href="https://mozilladatacollective.com/datasets/cmo1sg74a00cwmk07q6nin2of"
+                                target="_blank" class="absolute inset-0 z-20">
+                                </a>
+
+                                <div class="bg-[#0f0b16]/80 rounded-[0.9rem] p-6 h-full w-full relative overflow-hidden">
+                                    <div class="mb-3">
+                                        <span class="inline-flex items-center px-3 py-1 rounded-full text-[10px] sm:text-xs font-bold bg-purple-500/10 backdrop-blur-md border border-purple-500/20 text-purple-300 uppercase tracking-wider shadow-lg">
+                                            <span class="w-1.5 h-1.5 bg-purple-400 rounded-full mr-2 animate-pulse"></span>
+                                            <span id="date-16">ΑΠΡ 2026</span>
+                                        </span>
+                                    </div>
+
+                                    <h3 class="text-lg sm:text-xl font-bold text-white mb-2 group-hover:text-purple-300 transition-colors break-words">
+                                        ERT Press
+                                    </h3>
+
+                                    <div class="flex gap-2 sm:gap-4 mb-3 flex-wrap">
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-database mr-1"></i> 36.4MB
+                                        </div>
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-layer-group mr-1"></i> 9.8M Tokens
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Item 15: Modern Greek Dictionary -->
+                        <div class="roadmap-item relative mb-12 w-1/2 pr-6 sm:pr-12 text-right" data-index="15" id="roadmap-item-15">
+                            <div class="timeline-node node-left" id="node-15"></div>
+
+                            <div class="glass-box relative p-[5px] hover:border-purple-500/50 transition-colors group cursor-pointer"
+                                data-theme="purple" onclick="highlightChartPoint(15)">
+
+                                <a href="https://mozilladatacollective.com/datasets/cmo1sklpo00d0mk07taoepe1a"
+                                target="_blank" class="absolute inset-0 z-20">
+                                </a>
+
+                                <div class="bg-[#0f0b16]/80 rounded-[0.9rem] p-6 h-full w-full relative overflow-hidden">
+                                    <div class="mb-3">
+                                        <span class="inline-flex items-center px-3 py-1 rounded-full text-[10px] sm:text-xs font-bold bg-purple-500/10 backdrop-blur-md border border-purple-500/20 text-purple-300 uppercase tracking-wider shadow-lg">
+                                            <span class="w-1.5 h-1.5 bg-purple-400 rounded-full mr-2 animate-pulse"></span>
+                                            <span id="date-15">ΜΑΡ 2026</span>
+                                        </span>
+                                    </div>
+
+                                    <h3 class="text-lg sm:text-xl font-bold text-white mb-2 group-hover:text-purple-300 transition-colors break-words">
+                                        Modern Greek Dictionary
+                                    </h3>
+
+                                    <div class="flex justify-end gap-2 sm:gap-4 mb-3 flex-wrap">
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-database mr-1"></i> 33MB
+                                        </div>
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-layer-group mr-1"></i> 4.9M Tokens
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Item 14: Istorima -->
+                        <div class="roadmap-item relative mb-12 w-1/2 ml-auto pl-6 sm:pl-12 text-left" data-index="14" id="roadmap-item-14">
+                            <div class="timeline-node node-right" id="node-14"></div>
+
+                            <div class="glass-box relative p-[5px] hover:border-purple-500/50 transition-colors group cursor-pointer"
+                                data-theme="purple" onclick="highlightChartPoint(14)">
+
+                                <a href="https://mozilladatacollective.com/datasets/cmmxib8ic00v6nw07bjrci8vj"
+                                target="_blank" class="absolute inset-0 z-20">
+                                </a>
+
+                                <div class="bg-[#0f0b16]/80 rounded-[0.9rem] p-6 h-full w-full relative overflow-hidden">
+                                    <div class="mb-3">
+                                        <span class="inline-flex items-center px-3 py-1 rounded-full text-[10px] sm:text-xs font-bold bg-purple-500/10 backdrop-blur-md border border-purple-500/20 text-purple-300 uppercase tracking-wider shadow-lg">
+                                            <span class="w-1.5 h-1.5 bg-purple-400 rounded-full mr-2 animate-pulse"></span>
+                                            <span id="date-14">ΜΑΡ 2026</span>
+                                        </span>
+                                    </div>
+
+                                    <h3 class="text-lg sm:text-xl font-bold text-white mb-2 group-hover:text-purple-300 transition-colors break-words">
+                                        Istorima
+                                    </h3>
+
+                                    <div class="flex gap-2 sm:gap-4 mb-3 flex-wrap">
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-database mr-1"></i> 416.02MB
+                                        </div>
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-layer-group mr-1"></i> 138.9M Tokens
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
                         <!-- Item 13: openbook.gr -->
                         <div class="roadmap-item relative mb-12 w-1/2 pr-6 sm:pr-12 text-right" data-index="13" id="roadmap-item-13">
                             <div class="timeline-node node-left" id="node-13"></div>
@@ -1660,7 +1940,7 @@
                                         </p>
                                     </div>
                                     <div class="text-right">
-                                        <div class="text-2xl font-bold text-purple-400">7.513.846.854</div>
+                                        <div class="text-2xl font-bold text-purple-400">7.952.178.676</div>
                                         <div id="graph-total-badge" class="text-[10px] text-gray-500 uppercase">ΣΥΝΟΛΟ
                                             TOKENS</div>
                                     </div>
@@ -3577,9 +3857,9 @@
         document.addEventListener('DOMContentLoaded', function () {
             const ctx = document.getElementById('tokenChart').getContext('2d');
 
-            const labels = ['Nov 24', 'Nov 24', 'Nov 24', 'Dec 24', 'Dec 24', 'Dec 24', 'Jan 25', 'Jan 25', 'Mar 25', 'Apr 25', 'Apr 25', 'Jun 25', 'Jan 26', 'Jan 26'];
-            const cumulativeTokens = [96006, 3033270, 15290301, 25400278, 45843161, 83840260, 90352188, 123619911, 962864477, 1158960784, 1432036881, 2036069220, 7380296766, 7513846854];
-            const individualTokens = [96006, 2937264, 12257031, 10109977, 20442883, 37997099, 6511928, 33267723, 839244566, 196096307, 273076097, 604032339, 5344227546, 133550088];
+            const labels = ['Nov 24', 'Nov 24', 'Nov 24', 'Dec 24', 'Dec 24', 'Dec 24', 'Jan 25', 'Jan 25', 'Mar 25', 'Apr 25', 'Apr 25', 'Jun 25', 'Jan 26', 'Jan 26', 'Mar 26', 'Mar 26', 'Apr 26', 'Apr 26', 'Apr 26', 'Apr 26', 'Apr 26', 'Apr 26'];
+            const cumulativeTokens = [96006, 3033270, 15290301, 25400278, 45843161, 83840260, 90352188, 123619911, 962864477, 1158960784, 1432036881, 2036069220, 7380296766, 7513846854, 7652780219, 7657641137, 7667431793, 7825658233, 7829633307, 7832290811, 7943681530, 7952178676];
+            const individualTokens = [96006, 2937264, 12257031, 10109977, 20442883, 37997099, 6511928, 33267723, 839244566, 196096307, 273076097, 604032339, 5344227546, 133550088, 138933365, 4860918, 9790656, 158226440, 3975074, 2657504, 111390719, 8497146];
             const datasetNames = [
                 'dimodis_logotexnia',
                 '95k_deigma_ellinikis',
@@ -3594,7 +3874,15 @@
                 'ellinika_dedomena_europaikou_koinovouliou',
                 'eurlex-greek-legislation',
                 'Greek PhD Theses Corpus',
-                'openbook.gr'
+                'openbook.gr',
+                'Istorima',
+                'Modern Greek Dictionary',
+                'ERT Press',
+                'AMNA-press',
+                'artoszois',
+                'enautilia',
+                'opengov-deliberations-v2',
+                'eellak-articles'
             ];
 
             const gradient = ctx.createLinearGradient(0, 0, 0, 400);
@@ -3611,7 +3899,7 @@
                         borderColor: '#8b5cf6',
                         backgroundColor: gradient,
                         borderWidth: 3,
-                        pointBackgroundColor: Array(14).fill('#0f0b16'),
+                        pointBackgroundColor: Array(22).fill('#0f0b16'),
                         pointBorderColor: '#8b5cf6',
                         pointBorderWidth: 2,
                         pointRadius: 6,
@@ -3819,7 +4107,7 @@
                     title: "Dataset Timeline",
                     desc: "Tracking the <span class=\"text-purple-400 font-medium\">evolution</span> of our datasets and total token ingestion",
                     license: "All datasets are released under <span class=\"text-purple-400 font-bold\">Creative Commons</span> licenses",
-                    dates: ["NOV 2024", "NOV 2024", "NOV 2024", "DEC 2024", "DEC 2024", "DEC 2024", "JAN 2025", "JAN 2025", "MAR 2025", "APR 2025", "APR 2025", "JUN 2025", "JAN 2026"]
+                    dates: ["NOV 2024", "NOV 2024", "NOV 2024", "DEC 2024", "DEC 2024", "DEC 2024", "JAN 2025", "JAN 2025", "MAR 2025", "APR 2025", "APR 2025", "JUN 2025", "JAN 2026", "JAN 2026", "MAR 2026", "MAR 2026", "APR 2026", "APR 2026", "APR 2026", "APR 2026", "APR 2026", "APR 2026"]
                 },
                 graph: {
                     title: "Growth Chart",
@@ -3827,7 +4115,7 @@
                     totalLabel: "Total Tokens",
                     tooltipTotal: "Total",
                     totalBadge: "TOTAL TOKENS",
-                    chartLabels: ['Nov 24', 'Nov 24', 'Nov 24', 'Dec 24', 'Dec 24', 'Dec 24', 'Jan 25', 'Jan 25', 'Mar 25', 'Apr 25', 'Apr 25', 'Jun 25', 'Jan 26', 'Jan 26']
+                    chartLabels: ['Nov 24', 'Nov 24', 'Nov 24', 'Dec 24', 'Dec 24', 'Dec 24', 'Jan 25', 'Jan 25', 'Mar 25', 'Apr 25', 'Apr 25', 'Jun 25', 'Jan 26', 'Jan 26', 'Mar 26', 'Mar 26', 'Apr 26', 'Apr 26', 'Apr 26', 'Apr 26', 'Apr 26', 'Apr 26']
                 }
             },
             el: {
@@ -3867,7 +4155,7 @@
                     title: "Χρονολόγιο Δεδομένων",
                     desc: "Παρακολούθηση της <span class=\"text-purple-400 font-medium\">εξέλιξης</span> των δεδομένων μας και της συνολικής πρόσληψης tokens",
                     license: "Όλα τα σύνολα δεδομένων διατίθενται με άδειες <span class=\"text-purple-400 font-bold\">Creative Commons</span>",
-                    dates: ["ΝΟΕ 2024", "ΝΟΕ 2024", "ΝΟΕ 2024", "ΔΕΚ 2024", "ΔΕΚ 2024", "ΔΕΚ 2024", "ΙΑΝ 2025", "ΙΑΝ 2025", "ΜΑΡ 2025", "ΑΠΡ 2025", "ΑΠΡ 2025", "ΙΟΥΝ 2025", "ΙΑΝ 2026", "ΙΑΝ 2026"]
+                    dates: ["ΝΟΕ 2024", "ΝΟΕ 2024", "ΝΟΕ 2024", "ΔΕΚ 2024", "ΔΕΚ 2024", "ΔΕΚ 2024", "ΙΑΝ 2025", "ΙΑΝ 2025", "ΜΑΡ 2025", "ΑΠΡ 2025", "ΑΠΡ 2025", "ΙΟΥΝ 2025", "ΙΑΝ 2026", "ΙΑΝ 2026", "ΜΑΡ 2026", "ΜΑΡ 2026", "ΑΠΡ 2026", "ΑΠΡ 2026", "ΑΠΡ 2026", "ΑΠΡ 2026", "ΑΠΡ 2026", "ΑΠΡ 2026"]
                 },
                 graph: {
                     title: "Διάγραμμα Ανάπτυξης",
@@ -3875,7 +4163,7 @@
                     totalLabel: "Σύνολο Tokens",
                     tooltipTotal: "Σύνολο",
                     totalBadge: "ΣΥΝΟΛΟ TOKENS",
-                    chartLabels: ['Νοε 24', 'Νοε 24', 'Νοε 24', 'Δεκ 24', 'Δεκ 24', 'Δεκ 24', 'Ιαν 25', 'Ιαν 25', 'Μαρ 25', 'Απρ 25', 'Απρ 25', 'Ιουν 25', 'Ιαν 26', 'Ιαν 26']
+                    chartLabels: ['Νοε 24', 'Νοε 24', 'Νοε 24', 'Δεκ 24', 'Δεκ 24', 'Δεκ 24', 'Ιαν 25', 'Ιαν 25', 'Μαρ 25', 'Απρ 25', 'Απρ 25', 'Ιουν 25', 'Ιαν 26', 'Ιαν 26', 'Μαρ 26', 'Μαρ 26', 'Απρ 26', 'Απρ 26', 'Απρ 26', 'Απρ 26', 'Απρ 26', 'Απρ 26']
                 }
             }
         };


### PR DESCRIPTION
## Summary

Updates the Dataset Timeline / Χρονολόγιο Δεδομένων section on the homepage with 8 new datasets the team has released since openbook.gr (Jan 2026), keeps the cumulative-tokens chart in sync with the new entries, and fixes a small EN-only display bug on the existing openbook.gr card.

### New datasets added (chronological order, top → bottom on the timeline)

| # | Dataset | Date | Tokens | Source |
|---|---|---|---|---|
| 21 | eellak-articles | APR 2026 | 8,497,146 | Hugging Face |
| 20 | opengov-deliberations-v2 | APR 2026 | 111,390,719 | Hugging Face |
| 19 | enautilia | APR 2026 | 2,657,504 | Hugging Face |
| 18 | artoszois | APR 2026 | 3,975,074 | Hugging Face |
| 17 | AMNA-press | APR 2026 | 158,226,440 | Hugging Face |
| 16 | ERT Press | APR 2026 | 9,790,656 | Mozilla Data Collective |
| 15 | Modern Greek Dictionary | MAR 2026 | 4,860,918 | Mozilla Data Collective |
| 14 | Istorima | MAR 2026 | 138,933,365 | Mozilla Data Collective |

### Chart and total updates

- Extended `cumulativeTokens`, `individualTokens`, `datasetNames`, and the per-language `chartLabels` arrays from 14 → 22 entries.
- Updated the hardcoded grand total at the top-right of the chart card: **7.513.846.854 → 7.952.178.676**.
- Bumped `pointBackgroundColor: Array(14).fill(...)` → `Array(22).fill(...)`.

### Bug fix

`translations.en.timeline.dates` had only 13 entries (indices 0–12) while the timeline already had 14 cards (0–13). Item 13 (openbook.gr) therefore fell back to the hardcoded Greek `<span id="date-13">ΙΑΝ 2026</span>` even when viewing the site in English. Added `"JAN 2026"` as the 14th entry; the EN view now correctly shows "JAN 2026".

### Files changed

- `index.html` (+298 / −10) — only file touched. No new assets, no other pages affected.

## Test plan

- [ ] Open the merged page on `glossapi.gr` in Greek (default) — Χρονολόγιο Δεδομένων shows the 8 new cards above openbook.gr, with eellak-articles on top and Istorima just above openbook.gr.
- [ ] Switch to English (`?lang=en`) — same 8 cards with `MAR 2026` / `APR 2026` badges; openbook.gr now reads `JAN 2026` (not `ΙΑΝ 2026`).
- [ ] Cumulative-tokens chart on the right shows 8 additional points; rightmost value reads `7.952.178.676 ΣΥΝΟΛΟ TOKENS` / `TOTAL TOKENS`.
- [ ] Hovering chart points shows the new dataset names in tooltips (Istorima, Modern Greek Dictionary, ERT Press, AMNA-press, artoszois, enautilia, opengov-deliberations-v2, eellak-articles).
- [ ] Clicking each new card opens the correct dataset URL in a new tab and highlights the matching chart point.
