### PR TITLE
Update dataset timeline, reformat blog listing, fix contact CTA

### DIFF
--- a/aboutus.html
+++ b/aboutus.html
@@ -434,7 +434,7 @@
     <footer class="border-t border-white/10 py-8 mt-auto relative z-10 bg-[#0d0814]/60 backdrop-blur-md">
         <div class="max-w-7xl mx-auto px-6 flex flex-col md:flex-row justify-between items-center gap-4">
             <div class="text-gray-500 text-sm">
-                &copy; 2024 GlossAPI. Licensed under the EUPL v1.2.
+                &copy; 2026 GlossAPI. Licensed under the EUPL v1.2.
             </div>
             <div class="flex items-center gap-6 mt-4 md:mt-0">
                 <a href="https://discord.gg/TY69npdMwM" target="_blank"

--- a/article.html
+++ b/article.html
@@ -411,7 +411,7 @@
         style="background: rgba(13, 8, 20, 0.6); backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px);">
         <div class="max-w-7xl mx-auto px-6 flex flex-col md:flex-row justify-between items-center gap-4">
             <div class="text-gray-500 text-sm">
-                &copy; 2024 GlossAPI. Licensed under the EUPL v1.2.
+                &copy; 2026 GlossAPI. Licensed under the EUPL v1.2.
             </div>
             <div class="flex items-center gap-6 mt-4 md:mt-0">
                 <a href="https://discord.gg/TY69npdMwM" target="_blank"

--- a/blog.html
+++ b/blog.html
@@ -804,7 +804,7 @@
         style="background: rgba(13, 8, 20, 0.6); backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px);">
         <div class="max-w-7xl mx-auto px-6 flex flex-col md:flex-row justify-between items-center gap-4">
             <div class="text-gray-500 text-sm">
-                &copy; 2024 GlossAPI. Licensed under the EUPL v1.2.
+                &copy; 2026 GlossAPI. Licensed under the EUPL v1.2.
             </div>
             <div class="flex items-center gap-6 mt-4 md:mt-0">
                 <a href="https://discord.gg/TY69npdMwM" target="_blank"
@@ -926,8 +926,9 @@
                 new: "New",
                 journalTitle: "The GlossAPI Journal",
                 journalSubtitle: "Engineering notes on OCR, NLP, and Data Pipelines",
-                readArticle: "Read Article",
-                readStory: "Read Article",
+                readArticle: "Read article",
+                readStory: "Read article",
+                featured: "Featured",
                 insight: "Insight",
                 loading: "Loading...",
                 error: "Failed to load articles.",
@@ -940,8 +941,9 @@
                 new: "Νεο",
                 journalTitle: "Το Ημερολόγιο GlossAPI",
                 journalSubtitle: "Σημειώσεις μηχανικής για OCR, NLP και Data Pipelines",
-                readArticle: "Διαβάστε το Άρθρο",
-                readStory: "Διαβάστε το Άρθρο",
+                readArticle: "Διαβάστε το άρθρο",
+                readStory: "Διαβάστε το άρθρο",
+                featured: "Προτεινόμενο",
                 insight: "Ανάλυση",
                 loading: "Φόρτωση...",
                 error: "Αποτυχία φόρτωσης άρθρων.",
@@ -1094,23 +1096,23 @@
                 // Sort by date descending (WordPress already sorts, but ensure consistency)
                 articles.sort((a, b) => new Date(b.date) - new Date(a.date));
 
-                // Identify pinned (sticky posts in WordPress)
-                const pinnedArticles = articles.filter(a => a.sticky);
-                const otherArticles = articles.filter(a => !a.sticky);
+                // The most recent article (articles[0]) is always rendered as the single
+                // full-width featured hero at the top, exactly matching the WP blog layout
+                // at https://blog.glossapi.gr/blog/ where the latest post sits alone above
+                // the chronological list. The rest follow in a responsive grid below.
+                const featuredArticle = articles[0] || null;
+                const otherArticles = articles.slice(1);
 
                 let html = '';
                 const t = translations[currentLang];
 
-                // Render Featured
-                if (pinnedArticles.length > 0) {
-                    pinnedArticles.forEach(article => {
-                        html += renderFeatured(article, t);
-                    });
+                if (featuredArticle) {
+                    html += renderFeatured(featuredArticle, t);
                 }
 
-                // Render Grid
                 if (otherArticles.length > 0) {
-                    html += '<div class="grid grid-cols-2 gap-3 md:gap-8 md:grid-cols-2 lg:grid-cols-3 mt-12">';
+                    // Responsive grid: 1 col on mobile, 2 on tablet (md), 3 on desktop (lg)
+                    html += '<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8 mt-12">';
                     otherArticles.forEach(article => {
                         html += renderCard(article, t);
                     });
@@ -1206,7 +1208,7 @@
 
                             <div class="absolute top-6 left-6 z-20">
                                 <span class="inline-flex items-center px-4 py-2 rounded-full text-xs font-bold bg-purple-500/20 backdrop-blur-md border border-purple-500/30 text-white uppercase tracking-widest shadow-lg">
-                                    <span class="w-1.5 h-1.5 bg-purple-400 rounded-full mr-2 animate-pulse"></span> Featured
+                                    <span class="w-1.5 h-1.5 bg-purple-400 rounded-full mr-2 animate-pulse"></span> ${t.featured}
                                 </span>
                             </div>
                         </div>
@@ -1226,7 +1228,7 @@
                             </p>
                             
                             <div class="flex items-center justify-between pt-8 border-t border-white/5 group-hover:border-purple-500/20 transition-colors mt-auto">
-                                <span class="text-sm font-bold text-gray-500 group-hover:text-white transition-colors">Read Article</span>
+                                <span class="text-sm font-bold text-gray-500 group-hover:text-white transition-colors uppercase tracking-widest">${t.readArticle}</span>
                                 <div class="w-12 h-12 rounded-full bg-white/5 flex items-center justify-center group-hover:bg-purple-600 text-white transition-all duration-300 group-hover:scale-110 shadow-lg">
                                     <i class="fa-solid fa-arrow-right transform -rotate-45 group-hover:rotate-0 transition-transform duration-300"></i>
                                 </div>
@@ -1284,7 +1286,7 @@
                     </p>
                     
                     <div class="mt-auto flex items-center justify-between pt-4 border-t border-white/5 group-hover:border-purple-500/20 transition-colors">
-                        <span class="text-xs font-bold text-gray-500 group-hover:text-white transition-colors">Read Article</span>
+                        <span class="text-xs font-bold text-gray-500 group-hover:text-white transition-colors uppercase tracking-widest">${t.readArticle}</span>
                         <div class="w-8 h-8 rounded-full bg-white/5 flex items-center justify-center group-hover:bg-purple-600 text-white transition-all duration-300 group-hover:scale-110 shadow-lg">
                             <i class="fa-solid fa-arrow-right text-xs transform -rotate-45 group-hover:rotate-0 transition-transform duration-300"></i>
                         </div>

--- a/index.html
+++ b/index.html
@@ -1161,12 +1161,397 @@
                         <!-- Vertical Line -->
                         <div class="timeline-line"></div>
 
-                        <!-- Item 21: eellak-articles -->
+                        <!-- Item 30: new-sociology -->
+                        <div class="roadmap-item relative mb-12 w-1/2 ml-auto pl-6 sm:pl-12 text-left" data-index="30" id="roadmap-item-30">
+                            <div class="timeline-node node-right" id="node-30"></div>
+
+                            <div class="glass-box relative p-[5px] hover:border-purple-500/50 transition-colors group cursor-pointer"
+                                data-theme="purple" onclick="highlightChartPoint(30)">
+
+                                <a href="https://huggingface.co/datasets/glossAPI/new-sociology"
+                                target="_blank" class="absolute inset-0 z-20">
+                                </a>
+
+                                <div class="bg-[#0f0b16]/80 rounded-[0.9rem] p-6 h-full w-full relative overflow-hidden">
+                                    <div class="mb-3">
+                                        <span class="inline-flex items-center px-3 py-1 rounded-full text-[10px] sm:text-xs font-bold bg-purple-500/10 backdrop-blur-md border border-purple-500/20 text-purple-300 uppercase tracking-wider shadow-lg">
+                                            <span class="w-1.5 h-1.5 bg-purple-400 rounded-full mr-2 animate-pulse"></span>
+                                            <span id="date-30">ΙΟΥΝ 2026</span>
+                                        </span>
+                                    </div>
+
+                                    <h3 class="text-lg sm:text-xl font-bold text-white mb-2 group-hover:text-purple-300 transition-colors break-words">
+                                        new-sociology
+                                    </h3>
+
+                                    <div class="flex gap-2 sm:gap-4 mb-3 flex-wrap">
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-database mr-1"></i> 14.5MB
+                                        </div>
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-layer-group mr-1"></i> 6.1M Tokens
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Item 29: OpenCouncil -->
+                        <div class="roadmap-item relative mb-12 w-1/2 pr-6 sm:pr-12 text-right" data-index="29" id="roadmap-item-29">
+                            <div class="timeline-node node-left" id="node-29"></div>
+
+                            <div class="glass-box relative p-[5px] hover:border-purple-500/50 transition-colors group cursor-pointer"
+                                data-theme="purple" onclick="highlightChartPoint(29)">
+
+                                <a href="https://huggingface.co/datasets/glossAPI/OpenCouncil"
+                                target="_blank" class="absolute inset-0 z-20">
+                                </a>
+
+                                <div class="bg-[#0f0b16]/80 rounded-[0.9rem] p-6 h-full w-full relative overflow-hidden">
+                                    <div class="mb-3">
+                                        <span class="inline-flex items-center px-3 py-1 rounded-full text-[10px] sm:text-xs font-bold bg-purple-500/10 backdrop-blur-md border border-purple-500/20 text-purple-300 uppercase tracking-wider shadow-lg">
+                                            <span class="w-1.5 h-1.5 bg-purple-400 rounded-full mr-2 animate-pulse"></span>
+                                            <span id="date-29">ΙΟΥΝ 2026</span>
+                                        </span>
+                                    </div>
+
+                                    <h3 class="text-lg sm:text-xl font-bold text-white mb-2 group-hover:text-purple-300 transition-colors break-words">
+                                        OpenCouncil
+                                    </h3>
+
+                                    <div class="flex justify-end gap-2 sm:gap-4 mb-3 flex-wrap">
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-database mr-1"></i> 74.2MB
+                                        </div>
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-layer-group mr-1"></i> 11.5M Tokens
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Item 28: enautilia v2 -->
+                        <div class="roadmap-item relative mb-12 w-1/2 ml-auto pl-6 sm:pl-12 text-left" data-index="28" id="roadmap-item-28">
+                            <div class="timeline-node node-right" id="node-28"></div>
+
+                            <div class="glass-box relative p-[5px] hover:border-purple-500/50 transition-colors group cursor-pointer"
+                                data-theme="purple" onclick="highlightChartPoint(28)">
+
+                                <a href="https://huggingface.co/datasets/glossAPI/enautilia"
+                                target="_blank" class="absolute inset-0 z-20">
+                                </a>
+
+                                <div class="bg-[#0f0b16]/80 rounded-[0.9rem] p-6 h-full w-full relative overflow-hidden">
+                                    <div class="mb-3">
+                                        <span class="inline-flex items-center px-3 py-1 rounded-full text-[10px] sm:text-xs font-bold bg-purple-500/10 backdrop-blur-md border border-purple-500/20 text-purple-300 uppercase tracking-wider shadow-lg">
+                                            <span class="w-1.5 h-1.5 bg-purple-400 rounded-full mr-2 animate-pulse"></span>
+                                            <span id="date-28">ΙΟΥΝ 2026</span>
+                                        </span>
+                                    </div>
+
+                                    <h3 class="text-lg sm:text-xl font-bold text-white mb-2 group-hover:text-purple-300 transition-colors break-words">
+                                        enautilia v2
+                                    </h3>
+
+                                    <div class="flex gap-2 sm:gap-4 mb-3 flex-wrap">
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-database mr-1"></i> 1.46MB
+                                        </div>
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-layer-group mr-1"></i> 1.1M Tokens
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Item 27: artoszois v2 -->
+                        <div class="roadmap-item relative mb-12 w-1/2 pr-6 sm:pr-12 text-right" data-index="27" id="roadmap-item-27">
+                            <div class="timeline-node node-left" id="node-27"></div>
+
+                            <div class="glass-box relative p-[5px] hover:border-purple-500/50 transition-colors group cursor-pointer"
+                                data-theme="purple" onclick="highlightChartPoint(27)">
+
+                                <a href="https://huggingface.co/datasets/glossAPI/artoszois"
+                                target="_blank" class="absolute inset-0 z-20">
+                                </a>
+
+                                <div class="bg-[#0f0b16]/80 rounded-[0.9rem] p-6 h-full w-full relative overflow-hidden">
+                                    <div class="mb-3">
+                                        <span class="inline-flex items-center px-3 py-1 rounded-full text-[10px] sm:text-xs font-bold bg-purple-500/10 backdrop-blur-md border border-purple-500/20 text-purple-300 uppercase tracking-wider shadow-lg">
+                                            <span class="w-1.5 h-1.5 bg-purple-400 rounded-full mr-2 animate-pulse"></span>
+                                            <span id="date-27">ΙΟΥΝ 2026</span>
+                                        </span>
+                                    </div>
+
+                                    <h3 class="text-lg sm:text-xl font-bold text-white mb-2 group-hover:text-purple-300 transition-colors break-words">
+                                        artoszois v2
+                                    </h3>
+
+                                    <div class="flex justify-end gap-2 sm:gap-4 mb-3 flex-wrap">
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-database mr-1"></i> 6.24MB
+                                        </div>
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-layer-group mr-1"></i> 3.1M Tokens
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Item 26: heinrich_boell_stiftung -->
+                        <div class="roadmap-item relative mb-12 w-1/2 ml-auto pl-6 sm:pl-12 text-left" data-index="26" id="roadmap-item-26">
+                            <div class="timeline-node node-right" id="node-26"></div>
+
+                            <div class="glass-box relative p-[5px] hover:border-purple-500/50 transition-colors group cursor-pointer"
+                                data-theme="purple" onclick="highlightChartPoint(26)">
+
+                                <a href="https://huggingface.co/datasets/glossAPI/heinrich_boell_stiftung"
+                                target="_blank" class="absolute inset-0 z-20">
+                                </a>
+
+                                <div class="bg-[#0f0b16]/80 rounded-[0.9rem] p-6 h-full w-full relative overflow-hidden">
+                                    <div class="mb-3">
+                                        <span class="inline-flex items-center px-3 py-1 rounded-full text-[10px] sm:text-xs font-bold bg-purple-500/10 backdrop-blur-md border border-purple-500/20 text-purple-300 uppercase tracking-wider shadow-lg">
+                                            <span class="w-1.5 h-1.5 bg-purple-400 rounded-full mr-2 animate-pulse"></span>
+                                            <span id="date-26">ΙΟΥΝ 2026</span>
+                                        </span>
+                                    </div>
+
+                                    <h3 class="text-lg sm:text-xl font-bold text-white mb-2 group-hover:text-purple-300 transition-colors break-words">
+                                        heinrich_boell_stiftung
+                                    </h3>
+
+                                    <div class="flex gap-2 sm:gap-4 mb-3 flex-wrap">
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-database mr-1"></i> 120KB
+                                        </div>
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-layer-group mr-1"></i> 47.0K Tokens
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Item 25: psepheda -->
+                        <div class="roadmap-item relative mb-12 w-1/2 pr-6 sm:pr-12 text-right" data-index="25" id="roadmap-item-25">
+                            <div class="timeline-node node-left" id="node-25"></div>
+
+                            <div class="glass-box relative p-[5px] hover:border-purple-500/50 transition-colors group cursor-pointer"
+                                data-theme="purple" onclick="highlightChartPoint(25)">
+
+                                <a href="https://huggingface.co/datasets/glossAPI/psepheda"
+                                target="_blank" class="absolute inset-0 z-20">
+                                </a>
+
+                                <div class="bg-[#0f0b16]/80 rounded-[0.9rem] p-6 h-full w-full relative overflow-hidden">
+                                    <div class="mb-3">
+                                        <span class="inline-flex items-center px-3 py-1 rounded-full text-[10px] sm:text-xs font-bold bg-purple-500/10 backdrop-blur-md border border-purple-500/20 text-purple-300 uppercase tracking-wider shadow-lg">
+                                            <span class="w-1.5 h-1.5 bg-purple-400 rounded-full mr-2 animate-pulse"></span>
+                                            <span id="date-25">ΙΟΥΝ 2026</span>
+                                        </span>
+                                    </div>
+
+                                    <h3 class="text-lg sm:text-xl font-bold text-white mb-2 group-hover:text-purple-300 transition-colors break-words">
+                                        psepheda
+                                    </h3>
+
+                                    <div class="flex justify-end gap-2 sm:gap-4 mb-3 flex-wrap">
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-database mr-1"></i> 2.01GB
+                                        </div>
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-layer-group mr-1"></i> 769.3M Tokens
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Item 24: libduth -->
+                        <div class="roadmap-item relative mb-12 w-1/2 ml-auto pl-6 sm:pl-12 text-left" data-index="24" id="roadmap-item-24">
+                            <div class="timeline-node node-right" id="node-24"></div>
+
+                            <div class="glass-box relative p-[5px] hover:border-purple-500/50 transition-colors group cursor-pointer"
+                                data-theme="purple" onclick="highlightChartPoint(24)">
+
+                                <a href="https://huggingface.co/datasets/glossAPI/libduth"
+                                target="_blank" class="absolute inset-0 z-20">
+                                </a>
+
+                                <div class="bg-[#0f0b16]/80 rounded-[0.9rem] p-6 h-full w-full relative overflow-hidden">
+                                    <div class="mb-3">
+                                        <span class="inline-flex items-center px-3 py-1 rounded-full text-[10px] sm:text-xs font-bold bg-purple-500/10 backdrop-blur-md border border-purple-500/20 text-purple-300 uppercase tracking-wider shadow-lg">
+                                            <span class="w-1.5 h-1.5 bg-purple-400 rounded-full mr-2 animate-pulse"></span>
+                                            <span id="date-24">ΙΟΥΝ 2026</span>
+                                        </span>
+                                    </div>
+
+                                    <h3 class="text-lg sm:text-xl font-bold text-white mb-2 group-hover:text-purple-300 transition-colors break-words">
+                                        libduth
+                                    </h3>
+
+                                    <div class="flex gap-2 sm:gap-4 mb-3 flex-wrap">
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-database mr-1"></i> 1.4GB
+                                        </div>
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-layer-group mr-1"></i> 716.6M Tokens
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Item 23: libiep -->
+                        <div class="roadmap-item relative mb-12 w-1/2 pr-6 sm:pr-12 text-right" data-index="23" id="roadmap-item-23">
+                            <div class="timeline-node node-left" id="node-23"></div>
+
+                            <div class="glass-box relative p-[5px] hover:border-purple-500/50 transition-colors group cursor-pointer"
+                                data-theme="purple" onclick="highlightChartPoint(23)">
+
+                                <a href="https://huggingface.co/datasets/glossAPI/libiep"
+                                target="_blank" class="absolute inset-0 z-20">
+                                </a>
+
+                                <div class="bg-[#0f0b16]/80 rounded-[0.9rem] p-6 h-full w-full relative overflow-hidden">
+                                    <div class="mb-3">
+                                        <span class="inline-flex items-center px-3 py-1 rounded-full text-[10px] sm:text-xs font-bold bg-purple-500/10 backdrop-blur-md border border-purple-500/20 text-purple-300 uppercase tracking-wider shadow-lg">
+                                            <span class="w-1.5 h-1.5 bg-purple-400 rounded-full mr-2 animate-pulse"></span>
+                                            <span id="date-23">ΜΑΪ 2026</span>
+                                        </span>
+                                    </div>
+
+                                    <h3 class="text-lg sm:text-xl font-bold text-white mb-2 group-hover:text-purple-300 transition-colors break-words">
+                                        libiep
+                                    </h3>
+
+                                    <div class="flex justify-end gap-2 sm:gap-4 mb-3 flex-wrap">
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-database mr-1"></i> 1.46GB
+                                        </div>
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-layer-group mr-1"></i> 510.8M Tokens
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Item 22: greek-national-theatre-corpus -->
+                        <div class="roadmap-item relative mb-12 w-1/2 ml-auto pl-6 sm:pl-12 text-left" data-index="22" id="roadmap-item-22">
+                            <div class="timeline-node node-right" id="node-22"></div>
+
+                            <div class="glass-box relative p-[5px] hover:border-purple-500/50 transition-colors group cursor-pointer"
+                                data-theme="purple" onclick="highlightChartPoint(22)">
+
+                                <a href="https://huggingface.co/datasets/glossAPI/greek-national-theatre-corpus"
+                                target="_blank" class="absolute inset-0 z-20">
+                                </a>
+
+                                <div class="bg-[#0f0b16]/80 rounded-[0.9rem] p-6 h-full w-full relative overflow-hidden">
+                                    <div class="mb-3">
+                                        <span class="inline-flex items-center px-3 py-1 rounded-full text-[10px] sm:text-xs font-bold bg-purple-500/10 backdrop-blur-md border border-purple-500/20 text-purple-300 uppercase tracking-wider shadow-lg">
+                                            <span class="w-1.5 h-1.5 bg-purple-400 rounded-full mr-2 animate-pulse"></span>
+                                            <span id="date-22">ΜΑΪ 2026</span>
+                                        </span>
+                                    </div>
+
+                                    <h3 class="text-lg sm:text-xl font-bold text-white mb-2 group-hover:text-purple-300 transition-colors break-words">
+                                        greek-national-theatre-corpus
+                                    </h3>
+
+                                    <div class="flex gap-2 sm:gap-4 mb-3 flex-wrap">
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-database mr-1"></i> 42.58MB
+                                        </div>
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-layer-group mr-1"></i> 11.2M Tokens
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Item 21: elocus -->
                         <div class="roadmap-item relative mb-12 w-1/2 pr-6 sm:pr-12 text-right" data-index="21" id="roadmap-item-21">
                             <div class="timeline-node node-left" id="node-21"></div>
 
                             <div class="glass-box relative p-[5px] hover:border-purple-500/50 transition-colors group cursor-pointer"
                                 data-theme="purple" onclick="highlightChartPoint(21)">
+
+                                <a href="https://huggingface.co/datasets/glossAPI/elocus"
+                                target="_blank" class="absolute inset-0 z-20">
+                                </a>
+
+                                <div class="bg-[#0f0b16]/80 rounded-[0.9rem] p-6 h-full w-full relative overflow-hidden">
+                                    <div class="mb-3">
+                                        <span class="inline-flex items-center px-3 py-1 rounded-full text-[10px] sm:text-xs font-bold bg-purple-500/10 backdrop-blur-md border border-purple-500/20 text-purple-300 uppercase tracking-wider shadow-lg">
+                                            <span class="w-1.5 h-1.5 bg-purple-400 rounded-full mr-2 animate-pulse"></span>
+                                            <span id="date-21">ΜΑΪ 2026</span>
+                                        </span>
+                                    </div>
+
+                                    <h3 class="text-lg sm:text-xl font-bold text-white mb-2 group-hover:text-purple-300 transition-colors break-words">
+                                        elocus
+                                    </h3>
+
+                                    <div class="flex justify-end gap-2 sm:gap-4 mb-3 flex-wrap">
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-database mr-1"></i> 1.34GB
+                                        </div>
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-layer-group mr-1"></i> 568.7M Tokens
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Item 20: archetai -->
+                        <div class="roadmap-item relative mb-12 w-1/2 ml-auto pl-6 sm:pl-12 text-left" data-index="20" id="roadmap-item-20">
+                            <div class="timeline-node node-right" id="node-20"></div>
+
+                            <div class="glass-box relative p-[5px] hover:border-purple-500/50 transition-colors group cursor-pointer"
+                                data-theme="purple" onclick="highlightChartPoint(20)">
+
+                                <a href="https://huggingface.co/datasets/glossAPI/archetai"
+                                target="_blank" class="absolute inset-0 z-20">
+                                </a>
+
+                                <div class="bg-[#0f0b16]/80 rounded-[0.9rem] p-6 h-full w-full relative overflow-hidden">
+                                    <div class="mb-3">
+                                        <span class="inline-flex items-center px-3 py-1 rounded-full text-[10px] sm:text-xs font-bold bg-purple-500/10 backdrop-blur-md border border-purple-500/20 text-purple-300 uppercase tracking-wider shadow-lg">
+                                            <span class="w-1.5 h-1.5 bg-purple-400 rounded-full mr-2 animate-pulse"></span>
+                                            <span id="date-20">ΜΑΪ 2026</span>
+                                        </span>
+                                    </div>
+
+                                    <h3 class="text-lg sm:text-xl font-bold text-white mb-2 group-hover:text-purple-300 transition-colors break-words">
+                                        archetai
+                                    </h3>
+
+                                    <div class="flex gap-2 sm:gap-4 mb-3 flex-wrap">
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-database mr-1"></i> 265.71MB
+                                        </div>
+                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
+                                            <i class="fa-solid fa-layer-group mr-1"></i> 106.9M Tokens
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Item 19: eellak-articles -->
+                        <div class="roadmap-item relative mb-12 w-1/2 pr-6 sm:pr-12 text-right" data-index="19" id="roadmap-item-19">
+                            <div class="timeline-node node-left" id="node-19"></div>
+
+                            <div class="glass-box relative p-[5px] hover:border-purple-500/50 transition-colors group cursor-pointer"
+                                data-theme="purple" onclick="highlightChartPoint(19)">
 
                                 <a href="https://huggingface.co/datasets/glossAPI/eellak-articles"
                                 target="_blank" class="absolute inset-0 z-20">
@@ -1176,7 +1561,7 @@
                                     <div class="mb-3">
                                         <span class="inline-flex items-center px-3 py-1 rounded-full text-[10px] sm:text-xs font-bold bg-purple-500/10 backdrop-blur-md border border-purple-500/20 text-purple-300 uppercase tracking-wider shadow-lg">
                                             <span class="w-1.5 h-1.5 bg-purple-400 rounded-full mr-2 animate-pulse"></span>
-                                            <span id="date-21">ΑΠΡ 2026</span>
+                                            <span id="date-19">ΑΠΡ 2026</span>
                                         </span>
                                     </div>
 
@@ -1196,12 +1581,12 @@
                             </div>
                         </div>
 
-                        <!-- Item 20: opengov-deliberations-v2 -->
-                        <div class="roadmap-item relative mb-12 w-1/2 ml-auto pl-6 sm:pl-12 text-left" data-index="20" id="roadmap-item-20">
-                            <div class="timeline-node node-right" id="node-20"></div>
+                        <!-- Item 18: opengov-deliberations-v2 -->
+                        <div class="roadmap-item relative mb-12 w-1/2 ml-auto pl-6 sm:pl-12 text-left" data-index="18" id="roadmap-item-18">
+                            <div class="timeline-node node-right" id="node-18"></div>
 
                             <div class="glass-box relative p-[5px] hover:border-purple-500/50 transition-colors group cursor-pointer"
-                                data-theme="purple" onclick="highlightChartPoint(20)">
+                                data-theme="purple" onclick="highlightChartPoint(18)">
 
                                 <a href="https://huggingface.co/datasets/glossAPI/opengov-deliberations-v2"
                                 target="_blank" class="absolute inset-0 z-20">
@@ -1211,7 +1596,7 @@
                                     <div class="mb-3">
                                         <span class="inline-flex items-center px-3 py-1 rounded-full text-[10px] sm:text-xs font-bold bg-purple-500/10 backdrop-blur-md border border-purple-500/20 text-purple-300 uppercase tracking-wider shadow-lg">
                                             <span class="w-1.5 h-1.5 bg-purple-400 rounded-full mr-2 animate-pulse"></span>
-                                            <span id="date-20">ΑΠΡ 2026</span>
+                                            <span id="date-18">ΑΠΡ 2026</span>
                                         </span>
                                     </div>
 
@@ -1225,76 +1610,6 @@
                                         </div>
                                         <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
                                             <i class="fa-solid fa-layer-group mr-1"></i> 111.4M Tokens
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <!-- Item 19: enautilia -->
-                        <div class="roadmap-item relative mb-12 w-1/2 pr-6 sm:pr-12 text-right" data-index="19" id="roadmap-item-19">
-                            <div class="timeline-node node-left" id="node-19"></div>
-
-                            <div class="glass-box relative p-[5px] hover:border-purple-500/50 transition-colors group cursor-pointer"
-                                data-theme="purple" onclick="highlightChartPoint(19)">
-
-                                <a href="https://huggingface.co/datasets/glossAPI/enautilia"
-                                target="_blank" class="absolute inset-0 z-20">
-                                </a>
-
-                                <div class="bg-[#0f0b16]/80 rounded-[0.9rem] p-6 h-full w-full relative overflow-hidden">
-                                    <div class="mb-3">
-                                        <span class="inline-flex items-center px-3 py-1 rounded-full text-[10px] sm:text-xs font-bold bg-purple-500/10 backdrop-blur-md border border-purple-500/20 text-purple-300 uppercase tracking-wider shadow-lg">
-                                            <span class="w-1.5 h-1.5 bg-purple-400 rounded-full mr-2 animate-pulse"></span>
-                                            <span id="date-19">ΑΠΡ 2026</span>
-                                        </span>
-                                    </div>
-
-                                    <h3 class="text-lg sm:text-xl font-bold text-white mb-2 group-hover:text-purple-300 transition-colors break-words">
-                                        enautilia
-                                    </h3>
-
-                                    <div class="flex justify-end gap-2 sm:gap-4 mb-3 flex-wrap">
-                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
-                                            <i class="fa-solid fa-database mr-1"></i> 4.61MB
-                                        </div>
-                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
-                                            <i class="fa-solid fa-layer-group mr-1"></i> 2.7M Tokens
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <!-- Item 18: artoszois -->
-                        <div class="roadmap-item relative mb-12 w-1/2 ml-auto pl-6 sm:pl-12 text-left" data-index="18" id="roadmap-item-18">
-                            <div class="timeline-node node-right" id="node-18"></div>
-
-                            <div class="glass-box relative p-[5px] hover:border-purple-500/50 transition-colors group cursor-pointer"
-                                data-theme="purple" onclick="highlightChartPoint(18)">
-
-                                <a href="https://huggingface.co/datasets/glossAPI/artoszois"
-                                target="_blank" class="absolute inset-0 z-20">
-                                </a>
-
-                                <div class="bg-[#0f0b16]/80 rounded-[0.9rem] p-6 h-full w-full relative overflow-hidden">
-                                    <div class="mb-3">
-                                        <span class="inline-flex items-center px-3 py-1 rounded-full text-[10px] sm:text-xs font-bold bg-purple-500/10 backdrop-blur-md border border-purple-500/20 text-purple-300 uppercase tracking-wider shadow-lg">
-                                            <span class="w-1.5 h-1.5 bg-purple-400 rounded-full mr-2 animate-pulse"></span>
-                                            <span id="date-18">ΑΠΡ 2026</span>
-                                        </span>
-                                    </div>
-
-                                    <h3 class="text-lg sm:text-xl font-bold text-white mb-2 group-hover:text-purple-300 transition-colors break-words">
-                                        artoszois
-                                    </h3>
-
-                                    <div class="flex gap-2 sm:gap-4 mb-3 flex-wrap">
-                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
-                                            <i class="fa-solid fa-database mr-1"></i> 12.20MB
-                                        </div>
-                                        <div class="text-[10px] sm:text-xs text-gray-400 font-mono whitespace-nowrap">
-                                            <i class="fa-solid fa-layer-group mr-1"></i> 4.0M Tokens
                                         </div>
                                     </div>
                                 </div>
@@ -1940,7 +2255,7 @@
                                         </p>
                                     </div>
                                     <div class="text-right">
-                                        <div class="text-2xl font-bold text-purple-400">7.952.178.676</div>
+                                        <div class="text-2xl font-bold text-purple-400">10.650.929.548</div>
                                         <div id="graph-total-badge" class="text-[10px] text-gray-500 uppercase">ΣΥΝΟΛΟ
                                             TOKENS</div>
                                     </div>
@@ -1981,7 +2296,7 @@
                                     συνεισφέροντες.
                                 </p>
                                 <div class="flex justify-center">
-                                    <a href="https://blog.glossapi.gr/en/contibute-to-glossapi/" target="_blank"
+                                    <a href="mailto:glossapi.team@eellak.gr"
                                         class="relative inline-flex overflow-hidden rounded-full p-[6px] group">
                                         <span
                                             class="absolute inset-[-1000%] animate-[spin_3s_linear_infinite] bg-[conic-gradient(from_90deg_at_50%_50%,#000000_0%,#c084fc_50%,#000000_100%)]"></span>
@@ -2419,7 +2734,7 @@
         style="background: rgba(13, 8, 20, 0.6); backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px);">
         <div class="max-w-7xl mx-auto px-6 flex flex-col md:flex-row justify-between items-center gap-4">
             <div class="text-gray-500 text-sm">
-                &copy; 2024 GlossAPI. Licensed under the EUPL v1.2.
+                &copy; 2026 GlossAPI. Licensed under the EUPL v1.2.
             </div>
             <div class="flex items-center gap-6 mt-4 md:mt-0">
                 <a href="https://discord.gg/TY69npdMwM" target="_blank"
@@ -3852,9 +4167,9 @@
         document.addEventListener('DOMContentLoaded', function () {
             const ctx = document.getElementById('tokenChart').getContext('2d');
 
-            const labels = ['Nov 24', 'Nov 24', 'Nov 24', 'Dec 24', 'Dec 24', 'Dec 24', 'Jan 25', 'Jan 25', 'Mar 25', 'Apr 25', 'Apr 25', 'Jun 25', 'Jan 26', 'Jan 26', 'Mar 26', 'Mar 26', 'Apr 26', 'Apr 26', 'Apr 26', 'Apr 26', 'Apr 26', 'Apr 26'];
-            const cumulativeTokens = [96006, 3033270, 15290301, 25400278, 45843161, 83840260, 90352188, 123619911, 962864477, 1158960784, 1432036881, 2036069220, 7380296766, 7513846854, 7652780219, 7657641137, 7667431793, 7825658233, 7829633307, 7832290811, 7943681530, 7952178676];
-            const individualTokens = [96006, 2937264, 12257031, 10109977, 20442883, 37997099, 6511928, 33267723, 839244566, 196096307, 273076097, 604032339, 5344227546, 133550088, 138933365, 4860918, 9790656, 158226440, 3975074, 2657504, 111390719, 8497146];
+            const labels = ['Nov 24', 'Nov 24', 'Nov 24', 'Dec 24', 'Dec 24', 'Dec 24', 'Jan 25', 'Jan 25', 'Mar 25', 'Apr 25', 'Apr 25', 'Jun 25', 'Jan 26', 'Jan 26', 'Mar 26', 'Mar 26', 'Apr 26', 'Apr 26', 'Apr 26', 'Apr 26', 'May 26', 'May 26', 'May 26', 'May 26', 'Jun 26', 'Jun 26', 'Jun 26', 'Jun 26', 'Jun 26', 'Jun 26', 'Jun 26'];
+            const cumulativeTokens = [96006, 3033270, 15290301, 25400278, 45843161, 83840260, 90352188, 123619911, 962864477, 1158960784, 1432036881, 2036069220, 7380296766, 7513846854, 7652780219, 7657641137, 7667431793, 7825658233, 7937048952, 7945546098, 8052478815, 8621202404, 8632375033, 9143160240, 9859720411, 10629068426, 10629115421, 10632239974, 10633332952, 10644822636, 10650929548];
+            const individualTokens = [96006, 2937264, 12257031, 10109977, 20442883, 37997099, 6511928, 33267723, 839244566, 196096307, 273076097, 604032339, 5344227546, 133550088, 138933365, 4860918, 9790656, 158226440, 111390719, 8497146, 106932717, 568723589, 11172629, 510785207, 716560171, 769348015, 46995, 3124553, 1092978, 11489684, 6106912];
             const datasetNames = [
                 'dimodis_logotexnia',
                 '95k_deigma_ellinikis',
@@ -3874,10 +4189,19 @@
                 'Modern Greek Dictionary',
                 'ERT Press',
                 'AMNA-press',
-                'artoszois',
-                'enautilia',
                 'opengov-deliberations-v2',
-                'eellak-articles'
+                'eellak-articles',
+                'archetai',
+                'elocus',
+                'greek-national-theatre-corpus',
+                'libiep',
+                'libduth',
+                'psepheda',
+                'heinrich_boell_stiftung',
+                'artoszois v2',
+                'enautilia v2',
+                'OpenCouncil',
+                'new-sociology'
             ];
 
             const gradient = ctx.createLinearGradient(0, 0, 0, 400);
@@ -3894,7 +4218,7 @@
                         borderColor: '#8b5cf6',
                         backgroundColor: gradient,
                         borderWidth: 3,
-                        pointBackgroundColor: Array(22).fill('#0f0b16'),
+                        pointBackgroundColor: Array(31).fill('#0f0b16'),
                         pointBorderColor: '#8b5cf6',
                         pointBorderWidth: 2,
                         pointRadius: 6,
@@ -4102,7 +4426,7 @@
                     title: "Dataset Timeline",
                     desc: "Tracking the <span class=\"text-purple-400 font-medium\">evolution</span> of our datasets and total token ingestion",
                     license: "All datasets are released under <span class=\"text-purple-400 font-bold\">Creative Commons</span> licenses",
-                    dates: ["NOV 2024", "NOV 2024", "NOV 2024", "DEC 2024", "DEC 2024", "DEC 2024", "JAN 2025", "JAN 2025", "MAR 2025", "APR 2025", "APR 2025", "JUN 2025", "JAN 2026", "JAN 2026", "MAR 2026", "MAR 2026", "APR 2026", "APR 2026", "APR 2026", "APR 2026", "APR 2026", "APR 2026"]
+                    dates: ["NOV 2024", "NOV 2024", "NOV 2024", "DEC 2024", "DEC 2024", "DEC 2024", "JAN 2025", "JAN 2025", "MAR 2025", "APR 2025", "APR 2025", "JUN 2025", "JAN 2026", "JAN 2026", "MAR 2026", "MAR 2026", "APR 2026", "APR 2026", "APR 2026", "APR 2026", "MAY 2026", "MAY 2026", "MAY 2026", "MAY 2026", "JUN 2026", "JUN 2026", "JUN 2026", "JUN 2026", "JUN 2026", "JUN 2026", "JUN 2026"]
                 },
                 graph: {
                     title: "Growth Chart",
@@ -4110,7 +4434,7 @@
                     totalLabel: "Total Tokens",
                     tooltipTotal: "Total",
                     totalBadge: "TOTAL TOKENS",
-                    chartLabels: ['Nov 24', 'Nov 24', 'Nov 24', 'Dec 24', 'Dec 24', 'Dec 24', 'Jan 25', 'Jan 25', 'Mar 25', 'Apr 25', 'Apr 25', 'Jun 25', 'Jan 26', 'Jan 26', 'Mar 26', 'Mar 26', 'Apr 26', 'Apr 26', 'Apr 26', 'Apr 26', 'Apr 26', 'Apr 26']
+                    chartLabels: ['Nov 24', 'Nov 24', 'Nov 24', 'Dec 24', 'Dec 24', 'Dec 24', 'Jan 25', 'Jan 25', 'Mar 25', 'Apr 25', 'Apr 25', 'Jun 25', 'Jan 26', 'Jan 26', 'Mar 26', 'Mar 26', 'Apr 26', 'Apr 26', 'Apr 26', 'Apr 26', 'May 26', 'May 26', 'May 26', 'May 26', 'Jun 26', 'Jun 26', 'Jun 26', 'Jun 26', 'Jun 26', 'Jun 26', 'Jun 26']
                 }
             },
             el: {
@@ -4150,7 +4474,7 @@
                     title: "Χρονολόγιο Δεδομένων",
                     desc: "Παρακολούθηση της <span class=\"text-purple-400 font-medium\">εξέλιξης</span> των δεδομένων μας και της συνολικής πρόσληψης tokens",
                     license: "Όλα τα σύνολα δεδομένων διατίθενται με άδειες <span class=\"text-purple-400 font-bold\">Creative Commons</span>",
-                    dates: ["ΝΟΕ 2024", "ΝΟΕ 2024", "ΝΟΕ 2024", "ΔΕΚ 2024", "ΔΕΚ 2024", "ΔΕΚ 2024", "ΙΑΝ 2025", "ΙΑΝ 2025", "ΜΑΡ 2025", "ΑΠΡ 2025", "ΑΠΡ 2025", "ΙΟΥΝ 2025", "ΙΑΝ 2026", "ΙΑΝ 2026", "ΜΑΡ 2026", "ΜΑΡ 2026", "ΑΠΡ 2026", "ΑΠΡ 2026", "ΑΠΡ 2026", "ΑΠΡ 2026", "ΑΠΡ 2026", "ΑΠΡ 2026"]
+                    dates: ["ΝΟΕ 2024", "ΝΟΕ 2024", "ΝΟΕ 2024", "ΔΕΚ 2024", "ΔΕΚ 2024", "ΔΕΚ 2024", "ΙΑΝ 2025", "ΙΑΝ 2025", "ΜΑΡ 2025", "ΑΠΡ 2025", "ΑΠΡ 2025", "ΙΟΥΝ 2025", "ΙΑΝ 2026", "ΙΑΝ 2026", "ΜΑΡ 2026", "ΜΑΡ 2026", "ΑΠΡ 2026", "ΑΠΡ 2026", "ΑΠΡ 2026", "ΑΠΡ 2026", "ΜΑΪ 2026", "ΜΑΪ 2026", "ΜΑΪ 2026", "ΜΑΪ 2026", "ΙΟΥΝ 2026", "ΙΟΥΝ 2026", "ΙΟΥΝ 2026", "ΙΟΥΝ 2026", "ΙΟΥΝ 2026", "ΙΟΥΝ 2026", "ΙΟΥΝ 2026"]
                 },
                 graph: {
                     title: "Διάγραμμα Ανάπτυξης",
@@ -4158,7 +4482,7 @@
                     totalLabel: "Σύνολο Tokens",
                     tooltipTotal: "Σύνολο",
                     totalBadge: "ΣΥΝΟΛΟ TOKENS",
-                    chartLabels: ['Νοε 24', 'Νοε 24', 'Νοε 24', 'Δεκ 24', 'Δεκ 24', 'Δεκ 24', 'Ιαν 25', 'Ιαν 25', 'Μαρ 25', 'Απρ 25', 'Απρ 25', 'Ιουν 25', 'Ιαν 26', 'Ιαν 26', 'Μαρ 26', 'Μαρ 26', 'Απρ 26', 'Απρ 26', 'Απρ 26', 'Απρ 26', 'Απρ 26', 'Απρ 26']
+                    chartLabels: ['Νοε 24', 'Νοε 24', 'Νοε 24', 'Δεκ 24', 'Δεκ 24', 'Δεκ 24', 'Ιαν 25', 'Ιαν 25', 'Μαρ 25', 'Απρ 25', 'Απρ 25', 'Ιουν 25', 'Ιαν 26', 'Ιαν 26', 'Μαρ 26', 'Μαρ 26', 'Απρ 26', 'Απρ 26', 'Απρ 26', 'Απρ 26', 'Μαϊ 26', 'Μαϊ 26', 'Μαϊ 26', 'Μαϊ 26', 'Ιουν 26', 'Ιουν 26', 'Ιουν 26', 'Ιουν 26', 'Ιουν 26', 'Ιουν 26', 'Ιουν 26']
                 }
             }
         };


### PR DESCRIPTION
- Timeline: replace artoszois/enautilia v1 with v2, add archetai, elocus, greek-national-theatre-corpus, libiep, libduth, psepheda, heinrich_boell_stiftung, OpenCouncil, new-sociology (Apr-Jun 2026). 31 entries total, cumulative tokens now 10,650,929,548.
- Fix broken 'Get in touch' button: replace 404 WP URL with mailto:glossapi.team@eellak.gr.
- Blog listing: pick the latest post as the single full-width featured hero (no longer depends on WP sticky). Fix responsive grid from grid-cols-2 on mobile to grid-cols-1 md:grid-cols-2 lg:grid-cols-3. Localize 'Featured' and 'Read Article' to Greek (Prot/Diavaste).
- Bump footer copyright 2024 -> 2026 on index, aboutus, article, blog.